### PR TITLE
Allow cors on Speedtest

### DIFF
--- a/gluon-speedtest/files/lib/gluon/status-page/www/cgi-bin/devzero
+++ b/gluon-speedtest/files/lib/gluon/status-page/www/cgi-bin/devzero
@@ -1,4 +1,5 @@
 #!/bin/sh
+echo "Access-Control-Allow-Origin: *"
 echo
 cat /dev/zero
 


### PR DESCRIPTION
For a little micro speedtest like: http://speedtest.onffhb.de/:


![screenshot from 2018-04-26 10-33-33](https://user-images.githubusercontent.com/6905586/39294977-6b6ff2ee-493d-11e8-9ac4-b3906f24907f.png)
